### PR TITLE
edit btn working with modal and default values

### DIFF
--- a/frontend/public/athletes.json
+++ b/frontend/public/athletes.json
@@ -9,9 +9,9 @@
     "height": 174,
     "weight": 76,
     "skillLevel": "Advanced",
-    "personalObjective": "snaps",
-    "monthObjective": "improve bottom turn",
-    "threeMonthsObjective": "improve lip maneuvers reading",
+    "personalObjective": "Snaps",
+    "monthObjective": "Improve bottom turn",
+    "threeMonthsObjective": "Improve lip maneuvers reading",
     "sessionsCompleted": 3,
     "sessionsMissed": 1,
     "averageWavesPerSession": 12

--- a/frontend/src/components/athleteForm/AthleteForm.css
+++ b/frontend/src/components/athleteForm/AthleteForm.css
@@ -12,12 +12,12 @@
   margin-left: 20px;
 }
 
-.exit-btn{
+.exit-btn {
   font-size: 2rem;
   cursor: pointer;
 }
 
-.athlete-form .form-field{
+.athlete-form .form-field {
   margin-top: 10px;
   width: 100%;
 }
@@ -25,4 +25,26 @@
 .athlete-form .submit-btn {
   margin-top: 20px;
   width: 100%;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal-content {
+  background-color: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+  z-index: 500;
+  width: 80%;
 }

--- a/frontend/src/components/athleteForm/AthleteForm.jsx
+++ b/frontend/src/components/athleteForm/AthleteForm.jsx
@@ -1,18 +1,33 @@
-import React from 'react';
-import './AthleteForm.css'
+import React, { useState, useEffect } from 'react';
+import './AthleteForm.css';
 import { FormControl, TextField, Button } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleXmark } from '@fortawesome/free-solid-svg-icons';
 
-const AthleteForm = ({onClose}) => {
+const AthleteForm = ({ onClose, defaultValues, editMode }) => {
+  const [formData, setFormData] = useState(defaultValues || {});
+
+  // Update form data when default values change
+  useEffect(() => {
+    setFormData(defaultValues || {});
+  }, [defaultValues]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = () => {
+    // Handle form submission here
+  };
+
   return (
     <div className="athlete-form">
-
       <div className="top-bar">
-        <div/>
-        <h1>New Athlete</h1>
-        <FontAwesomeIcon className="exit-btn" icon={faCircleXmark} onClick={onClose}/>
+        <div />
+        <h1>{editMode ? 'Edit Athlete' : 'New Athlete'}</h1> {/* rendering the title in a conditional way. Passed editMode value throught props from AthleteProfile to now its "Edit Athlete" instead of "New Athlete" */}
+        <FontAwesomeIcon className="exit-btn" icon={faCircleXmark} onClick={onClose} />
       </div>
 
       <FormControl>
@@ -20,40 +35,58 @@ const AthleteForm = ({onClose}) => {
           label="Name"
           fullWidth
           className="form-field"
+          name="name"
+          value={formData.name || ''}
+          onChange={handleChange}
         />
         <TextField
           label="Email"
           fullWidth
           className="form-field"
+          name="email"
+          value={formData.email || ''}
+          onChange={handleChange}
         />
         <TextField
           label="Birthdate"
           fullWidth
           className="form-field"
+          name="birthdate"
+          value={formData.birthdate || ''}
+          onChange={handleChange}
         />
         <TextField
           label="Height"
           fullWidth
           className="form-field"
+          name="height"
+          value={formData.height || ''}
+          onChange={handleChange}
         />
         <TextField
           label="Weight"
           fullWidth
           className="form-field"
+          name="weight"
+          value={formData.weight || ''}
+          onChange={handleChange}
         />
         <Autocomplete
           className="form-field"
           options={['Performance', 'Advanced', 'Intermediate', 'Beginner']}
-          renderInput={(params) => (
-            <TextField {...params} label="Skill Level" />
-          )}
+          value={formData.skillLevel || ''} // Set the initial value based on the formData state
+          onChange={(event, value) => setFormData({ ...formData, skillLevel: value })} // Update the formData state when the value changes
+          renderInput={(params) => <TextField {...params} label="Skill Level" />} // Render the input field
         />
         <TextField
           label="Personal Objective"
           fullWidth
           className="form-field"
+          name="personalObjective"
+          value={formData.personalObjective || ''}
+          onChange={handleChange}
         />
-        <Button className="submit-btn" variant="contained" color="primary">
+        <Button className="submit-btn" variant="contained" color="primary" onClick={handleSubmit}>
           Submit
         </Button>
       </FormControl>

--- a/frontend/src/components/athleteProfile/AthleteProfile.jsx
+++ b/frontend/src/components/athleteProfile/AthleteProfile.jsx
@@ -4,12 +4,13 @@ import './AthleteProfile.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCircleChevronLeft, faUserPen } from '@fortawesome/free-solid-svg-icons';
 import { useNavigate } from 'react-router-dom';
-
+import AthleteForm from '../athleteForm/AthleteForm';
 
 const AthleteProfile = () => {
   const { id } = useParams();
   const [athlete, setAthlete] = useState(null);
   const [activeTab, setActiveTab] = useState('profile');
+  const [showForm, setShowForm] = useState(false);
 
   const navigate = useNavigate();
 
@@ -31,23 +32,25 @@ const AthleteProfile = () => {
     setActiveTab(tab);
   };
 
+  // to display the current month in the Monthly Objective
+  const currentDate = new Date();
+  const currentMonth = currentDate.toLocaleString('default', { month: 'long' });
 
-// to display the current month in the Monthly Objective
-const currentDate = new Date();
-const currentMonth = currentDate.toLocaleString('default', { month: 'long' });
+  const handleOpenForm = () => {
+    setShowForm(true);
+  };
 
-
-
+  const handleCloseForm = () => {
+    setShowForm(false);
+  };
 
   return (
     <div className="athlete">
-
       <div className="athlete-top">
         <FontAwesomeIcon icon={faCircleChevronLeft} className="back-btn" onClick={() => navigate(-1)} />
         <h2>{athlete && athlete.name}</h2>
-        <FontAwesomeIcon icon={faUserPen} className="edit-btn" onClick="" />
+        <FontAwesomeIcon icon={faUserPen} className="edit-btn" onClick={handleOpenForm} />
       </div>
-
       <div className="athlete-navbar">
         <button onClick={() => handleTabChange('profile')}>Profile</button>
         <button onClick={() => handleTabChange('objectives')}>Objectives</button>
@@ -89,10 +92,16 @@ const currentMonth = currentDate.toLocaleString('default', { month: 'long' });
             <div>
               <p>show scheduled sessions here</p>
               <hr/>
-
             </div>
           )}
         </>
+      )}
+      {showForm && athlete && (
+        <div className="modal-overlay">
+          <div className="modal-content">
+            <AthleteForm onClose={handleCloseForm} defaultValues={athlete} editMode/>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
edit-btn in athleteProfile now shows the same form as the add-btn in Athletes

initializes a state variable formData using the useState hook. The initial state is set to defaultValue
formData represents the data entered by the user in the form fields.
useEffect hook is used to update the formData state whenever the defaultValues prop changes.
callback function inside useEffect is executed whenever the dependencies array [defaultValues] changes

handleChange is called whenever there's a change in any form field
It extracts the name and value from the event target (the form field that triggered the change)
Then, it updates the formData state by spreading the existing data and adding or updating the property with the new value

the handleSubmit function is not done


in ProfileForm added to each TextField:
- the name attribute, of the input field, which is used to identify the form data when it's submitted 
- the value attribute, binds the value of the input field to the corresponding property in the formData state.
   -> If formData.birthdate exists and is not null or undefined, it will be displayed in the input field.
   -> If formData.birthdate is null or undefined, an empty string '' will be displayed. (used in athletes.jsx add-btn)
 - the handleChange function is assigned to onChange. The function is responsible for updating the formData state with the new value entered by the user. (BUT THE SUBMIT BUTTON IS NOT YET WORKING!)